### PR TITLE
Issue 31: Have the backend api serve mailcode id with the user

### DIFF
--- a/api/src/routes/asset-owner-router.ts
+++ b/api/src/routes/asset-owner-router.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response } from "express";
+import express, { Request, Response, NextFunction } from "express";
 import { body, param } from "express-validator";
 import { ReturnValidationErrors } from "../middleware";
 import _ from "lodash";
@@ -7,16 +7,21 @@ export const assetOwnerRouter = express.Router();
 
 import { db } from "../data";
 
-assetOwnerRouter.get("/",
-    async (req: Request, res: Response) => {
-        let list = await db("asset_owner").orderBy("mailcode").orderBy("name");
+assetOwnerRouter.get(
+    "/",
+    async (req: Request, res: Response, next: NextFunction) => {
+        let list = await db("asset_owner")
+            .orderBy("mailcode")
+            .orderBy("name")
+            .catch(next);
 
         for (let item of list) {
-            item.display_name = `(${item.mailcode}) ${item.name}`
+            item.display_name = `(${item.mailcode}) ${item.name}`;
         }
 
         return res.json({ data: list });
-    });
+    }
+);
 
 assetOwnerRouter.get("/:id", [param("id").notEmpty().isInt()], ReturnValidationErrors,
     async (req: Request, res: Response) => {

--- a/api/src/routes/asset-tag-router.ts
+++ b/api/src/routes/asset-tag-router.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response } from "express";
+import express, { Request, Response, NextFunction } from "express";
 import { body, param } from "express-validator";
 import moment from "moment";
 import _ from "lodash";
@@ -396,11 +396,14 @@ assetTagRouter.put(
   }
 );
 
-assetTagRouter.get("/asset-category", async (req: Request, res: Response) => {
-  let list = await db("asset_category");
+assetTagRouter.get(
+  "/asset-category",
+  async (req: Request, res: Response, next: NextFunction) => {
+    let list = await db("asset_category").catch(next);
 
-  return res.json({ data: list });
-});
+    return res.json({ data: list });
+  }
+);
 
 assetTagRouter.delete("/:id", async (req: Request, res: Response) => {
   let { id } = req.params;

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -78,21 +78,23 @@ export function configureAuthentication(app: Express) {
             //(req.session as any).user = oidcUser;
             //req.user = oidcUser;
 
-            let dbUser = await userService.getByEmail(oidcUser.email);
-            req.user = await userService.makeDTO(
-                Object.assign(oidcUser, dbUser)
-            );
+            let dbUser = await userService
+                .getByEmail(oidcUser.email)
+                .catch(next);
+            req.user = userService.makeDTO(Object.assign(oidcUser, dbUser));
         }
 
         next();
     });
 
-    app.get("/", async (req: Request, res: Response) => {
+    app.get("/", async (req: Request, res: Response, next: NextFunction) => {
         if (req.oidc.isAuthenticated()) {
             let user = AuthUser.fromOpenId(req.oidc.user) as AuthUser;
             req.user = user;
 
-            let dbUser = await userService.getByEmail(req.user.email);
+            let dbUser = await userService
+                .getByEmail(req.user.email)
+                .catch(next);
 
             if (!dbUser) {
                 console.log("CREATING USER");

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -1,13 +1,13 @@
 import { Express, NextFunction, Request, Response } from "express";
 import * as ExpressSession from "express-session";
 
-import { AuthUser } from "../data";
+import { db, AuthUser } from "../data";
 import { AUTH_REDIRECT, FRONTEND_URL, V2_API_KEY_REMOTE } from "../config";
 import { UserService } from "../services";
 
 import { auth } from "express-openid-connect";
 
-const userService = new UserService();
+const userService = new UserService(db);
 
 const V2_API_REGEX = /^\/api\/v2\/.*/;
 

--- a/api/src/routes/user-router.ts
+++ b/api/src/routes/user-router.ts
@@ -1,6 +1,7 @@
 import express, { Request, Response } from "express";
 import { body, param } from "express-validator";
 
+import { db } from "../data";
 import { ReturnValidationErrors } from "../middleware";
 import { UserService } from "../services";
 import _ from "lodash";
@@ -10,9 +11,23 @@ export const userRouter = express.Router();
 const userService = new UserService(db);
 
 userRouter.get("/me", async (req: Request, res: Response) => {
-    let person = req.user;
-    let me = await userService.getByEmail(person.email);
-    return res.json({ data: await userService.makeDTO(Object.assign(req.user, me)) });
+    const currentUser = req.user;
+    const user = await userService.getByEmail(currentUser.email);
+
+    const { id: mailcodeId } = await db
+        .select("id")
+        .from("asset_owner")
+        .where({ mailcode: user.mailcode })
+        .first();
+
+    const userProfile = await userService.makeDTO({
+        mailcodeId,
+        ...currentUser,
+        ...user,
+    });
+    return res.json({
+        data: userProfile,
+    });
 });
 
 userRouter.get("/", async (req: Request, res: Response) => {

--- a/api/src/routes/user-router.ts
+++ b/api/src/routes/user-router.ts
@@ -7,7 +7,7 @@ import _ from "lodash";
 
 export const userRouter = express.Router();
 
-const userService = new UserService();
+const userService = new UserService(db);
 
 userRouter.get("/me", async (req: Request, res: Response) => {
     let person = req.user;

--- a/api/src/services/user-service.ts
+++ b/api/src/services/user-service.ts
@@ -1,7 +1,15 @@
+import { Knex } from "knex";
 import _ from "lodash";
+
 import { db } from "../data";
 
 export class UserService {
+    readonly db: Knex;
+
+    constructor(db: Knex) {
+        this.db = db;
+    }
+
     async create(
         email: string,
         first_name: string,
@@ -9,7 +17,9 @@ export class UserService {
         status: string,
         roles: string
     ): Promise<any> {
-        let existing = await db("user").where({ email }).count("email as cnt");
+        let existing = await this.db("user")
+            .where({ email })
+            .count("email as cnt");
 
         if (existing[0].cnt > 0) return undefined;
 
@@ -22,19 +32,19 @@ export class UserService {
             create_date: new Date(),
         };
 
-        return await db("user").insert(user);
+        return await this.db("user").insert(user);
     }
 
     async update(email: string, item: any) {
-        return db("user").where({ email }).update(item);
+        return this.db("user").where({ email }).update(item);
     }
 
     async getAll() {
-        return db("user");
+        return this.db("user");
     }
 
     async getByEmail(email: string): Promise<any | undefined> {
-        return db("user").where({ email }).first();
+        return this.db("user").where({ email }).first();
     }
 
     async getAccessFor(email: string): Promise<string[]> {
@@ -54,7 +64,7 @@ export class UserService {
         dto.manage_mailcodes = _.split(userRaw.manage_mailcodes, ",").filter(
             (r: string) => r.length > 0
         );
-        //dto.access = await db.getAccessFor(userRaw.email);
+        //dto.access = await this.db.getAccessFor(userRaw.email);
         //dto.display_access = _.join(dto.access.map((a: any) => a.level), ", ")
 
         return dto;

--- a/api/src/services/user-service.ts
+++ b/api/src/services/user-service.ts
@@ -44,7 +44,22 @@ export class UserService {
     }
 
     async getByEmail(email: string): Promise<any | undefined> {
-        return this.db("user").where({ email }).first();
+        return this.db("user")
+            .where({ email })
+            .first()
+            .then((user) => {
+                if (!user) return;
+
+                return this.db
+                    .select("id")
+                    .from("asset_owner")
+                    .where({ mailcode: user.mailcode })
+                    .first()
+                    .then((assetOwner) => {
+                        user.mailcodeId = assetOwner.mailcodeId || -1;
+                        return user;
+                    });
+            });
     }
 
     async getAccessFor(email: string): Promise<string[]> {


### PR DESCRIPTION
# Context

The user table is currently storing mailcode as string, but we want the mailcode id in the front-end. The API code can handle the conversion rather than writing a database migration.

# Implementation
Compute the mailcode id (asset_owner#id) and return it with all requests for the user object.
Use correct syntax for handing errors in Promises to avoid server crash on login.

**Rule: you must always at least `.catch(next)` when `await`ing or `return`ing Promises unless using Express 5 or higher**
